### PR TITLE
Fix try call & related check

### DIFF
--- a/R/olson.R
+++ b/R/olson.R
@@ -161,7 +161,7 @@ safe_get_tz_info <- function(tz, yr) {
                by = "1 day")
   offs <- try(tz_offset(dates, tz))
 
-  if (class(offs) == "try-error") return(NULL)
+  if (inherits(offs, "try-error")) return(NULL)
 
   unique(offs[, setdiff(names(offs), "date_time")])
 }

--- a/R/olson.R
+++ b/R/olson.R
@@ -159,7 +159,7 @@ safe_get_tz_info <- function(tz, yr) {
   dates <- seq(as.Date(paste0(yr,"-01-01"), format = "%Y-%m-%d"),
                as.Date(paste0(yr,"-12-31"), format = "%Y-%m-%d"),
                by = "1 day")
-  offs <- try(tz_offset(dates, tz))
+  offs <- try(tz_offset(dates, tz), silent = TRUE)
 
   if (inherits(offs, "try-error")) return(NULL)
 


### PR DESCRIPTION
This PR does two things, cherry-picking from #14.

1. It uses `silent = TRUE` to not emit the error if thrown by the call wrapped in `try()`, and
2. It uses `inherits()` to test for the `"try-error"` class instead of matching equality between `class(x)` and string `"try-error"`. This latter usage now results in a NOTE under ´R CMD check´.